### PR TITLE
Allow using named splat (`*name`)

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -1,0 +1,26 @@
+name: Docker build (edge)
+on:
+  push: { branches: master }
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: edge
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: dannyben/redirectly:edge

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.gem
 /cache
 /coverage
-/debug.rb
+/debug.runfile
 /dev
 /Gemfile.lock
 /gems

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:3-alpine
+
+ENV PS1 "\n\n>> redirectly \W \$ "
+RUN apk add --no-cache git build-base
+
+ARG branch=master
+
+WORKDIR /redirectly
+RUN git clone --branch $branch --depth 1 https://github.com/DannyBen/redirectly.git .
+RUN gem build redirectly.gemspec --output redirectly.gem
+RUN gem install redirectly.gem
+RUN rm -rf /redirectly
+
+VOLUME /app
+WORKDIR /app
+EXPOSE 3000
+
+ENTRYPOINT ["redirectly"]

--- a/edge/README.md
+++ b/edge/README.md
@@ -1,0 +1,20 @@
+# Testing Unreleased (Edge) Redirectly Versions
+
+If you wish to try a version of redirectly straight from GitHub before it is
+released, you can use one of these methods:
+
+## Using Docker
+
+```bash
+$ docker pull dannyben/redirectly:edge
+```
+
+## Using Ruby
+
+```bash
+git clone --depth 1 https://github.com/DannyBen/redirectly.git
+cd redirectly
+gem build redirectly.gemspec --output redirectly.gem
+gem install redirectly.gem
+cd ..
+```

--- a/edge/op.conf
+++ b/edge/op.conf
@@ -1,0 +1,2 @@
+build: docker build --build-arg=branch=${1:-master} --no-cache -t dannyben/redirectly:edge . && docker images |grep redirectly
+push: docker push dannyben/redirectly:edge

--- a/lib/redirectly.rb
+++ b/lib/redirectly.rb
@@ -1,4 +1,4 @@
-require 'byebug' if ENV['BYEBUG']
+require 'debug' if ENV['DEBUGGER']
 
 require 'redirectly/refinements'
 require 'redirectly/version'

--- a/lib/redirectly/app.rb
+++ b/lib/redirectly/app.rb
@@ -45,7 +45,7 @@ module Redirectly
     end
 
     def ini_read(path)
-      content = File.readlines(path, chomp: true).reject(&:comment?)
+      content = File.readlines(path, chomp: true).reject(&:comment?).reject(&:empty?)
       content.to_h { |line| line.split(/\s*=\s*/, 2) }
     end
 
@@ -72,7 +72,6 @@ module Redirectly
       if params
         params.transform_keys!(&:to_sym)
         params.delete :splat
-        params.transform_values! { |v| CGI.escape v }
       end
 
       params

--- a/spec/fixtures/redirects.ini
+++ b/spec/fixtures/redirects.ini
@@ -5,3 +5,4 @@ perm.localhost = !https://permanent.com
 :sub.domain.com = https://new-site.com/%{sub}
 query.com = https://redir.com?already=have&query=string
 *.localhost = https://anything-else.com
+(*)splat.localhost/*rest = https://example.com/%{rest}

--- a/spec/redirectly/app_spec.rb
+++ b/spec/redirectly/app_spec.rb
@@ -14,11 +14,11 @@ describe App do
   end
 
   context 'with a request that uses :args' do
-    subject { host_get 'find.localhost/hello%20world&+' }
+    subject { host_get 'find.localhost/hello%20world' }
 
     it 'redirects and replaces the args in the target' do
       expect(subject).to be_redirection
-      expect(last_response.location).to eq 'https://search.com/?q=hello+world%26%2B'
+      expect(last_response.location).to eq 'https://search.com/?q=hello world'
     end
   end
 

--- a/spec/redirectly/app_spec.rb
+++ b/spec/redirectly/app_spec.rb
@@ -67,6 +67,15 @@ describe App do
     end
   end
 
+  context 'with a request that uses a named splat' do
+    subject { host_get 'anything.splat.localhost/1/2/3/4?5=6' }
+
+    it 'redirects' do
+      expect(subject).to be_redirection
+      expect(last_response.location).to eq 'https://example.com/1/2/3/4?5=6'
+    end
+  end
+
   context 'with a target that wants a permanent redirect' do
     subject { host_get 'perm.localhost' }
 


### PR DESCRIPTION
This PR makes it so the following pattern works:

```ini
(*)localhost/*rest = https://example.com/%{rest}
```

in addition to some other changes:

- **BREAKING CHANGE**: Arguments are no longer URI-escaped
- Empty lines in the INI file are now also ignored
- Replace `byebug` with `debug`


cc #10