### PR TITLE
Add support for proxy mode URLs

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = coverage,Gemfile.lock,sublime*
+; ignore-words-list = bu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['3.0', '3.1', '3.2', '3.3'] }
+      matrix: { ruby: ['3.1', '3.2', '3.3'] }
 
     steps:
     - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 *.gem
 /cache
-/coverage
 /debug.runfile
 /dev
 /Gemfile.lock
 /gems
 /redirects.ini
+/spec/coverage
 /spec/tmp
 /tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,4 +8,5 @@ inherit_gem:
     - rspec.yml
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
+  SuggestExtensions: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
-Change Log
+Changelog
 ========================================
+
+Untagged - Latest
+----------------------------------------
+
+- Add support for proxy mode URLs
+- Drop support for Ruby 3.0
+
 
 v0.3.0 - 2024-02-13
 ----------------------------------------
 
 - Build docker images automatically
-- BREAKING: Remove URI encoding of arguments in target URL
 - Allow using named splat (`*name`)
 - Add redirectly:edge docker image
 - Update `--init` template to include a splat redirect
@@ -18,12 +24,13 @@ v0.2.0 - 2024-02-07
 - Upgrade rack to 3.0
 
 
+<!-- break v0.1.2 -->
 v0.1.2 - 2023-03-19
 ----------------------------------------
 
 - Forward query strings from source to target
 - Drop support for Ruby < 2.6
-- Upgade dependencies
+- Upgrade dependencies
 
 
 v0.1.1 - 2021-07-05
@@ -37,5 +44,3 @@ v0.0.0 - 2021-07-05
 
 - Initial version
 - Implement --init
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM ruby:3-alpine
 
 ENV TERM=linux
-ENV PS1 "\n\n>> redirectly \W \$ "
+ENV PS1="\n\n>> redirectly \W \$ "
 
 RUN apk --no-cache add build-base
 
 RUN gem install redirectly -v 0.3.0
 
 WORKDIR /app
+VOLUME /app
 EXPOSE 3000
 
 ENTRYPOINT ["redirectly"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ example.com = https://other-site.com/
 example.org/* = https://other-site.com/
 *.old-site.com = !https://permanent.redirect.com
 :sub.app.localhost/* = http://it-works.com/%{sub}
+proxy.localhost/*rest = @https://proxy.target.com/base/*rest
 (*)old-domain.com/*rest = http://new-domain.com/%{rest}
 ```
 
@@ -109,13 +110,23 @@ The configuration file is built of `pattern = target` pairs, where:
 - `pattern` - is any URL pattern that is supported by [Mustermann][mustermann].
 - `target` - is the target URL to redirect to.
 
-Notes:
+### Notes
 
-- If `target` starts with an exclamation mark, it will be a permanent
-  redirect (301), otherwise it will be a temporary redirect (302).
-- If `pattern` includes named arguments (e.g. `example.com/:something`), they
-  will be available to the `target` as Ruby string substitution variables
-  (e.g. `%{something}`).
+#### Redirects
+
+If the target starts with `!`, it will perform a permanent redirect (301).
+Otherwise, it will perform a temporary redirect (302) by default.
+
+#### Proxying
+
+If the target starts with `@`, the content will be proxied instead of being
+redirected.
+
+#### Named Arguments in Patterns
+
+If the pattern includes named arguments (e.g., example.com/**:something**),
+those arguments will be available as Ruby string substitution variables in the
+target (e.g., **%{something}**).
 
 
 ## Contributing / Support

--- a/lib/redirectly/command.rb
+++ b/lib/redirectly/command.rb
@@ -44,6 +44,7 @@ module Redirectly
         example.org/* = https://other-site.com/
         *.old-site.com = !https://permanent.redirect.com
         :sub.app.localhost/* = http://it-works.com/%{sub}
+        proxy.localhost/*rest = @https://proxy.target.com/base/*rest
         (*)old-domain.com/*rest = http://new-domain.com/%{rest}
       TEMPLATE
     end

--- a/redirectly.gemspec
+++ b/redirectly.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.executables = ['redirectly']
   s.homepage    = 'https://github.com/dannyben/redirectly'
   s.license     = 'MIT'
-  s.required_ruby_version = '>= 3.0'
+
+  s.required_ruby_version = '>= 3.1'
 
   s.add_dependency 'mister_bin', '~> 0.7'
   s.add_dependency 'mustermann', '>= 1.1', '< 4'

--- a/redirectly.gemspec
+++ b/redirectly.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = '>= 3.0'
 
-  s.add_runtime_dependency 'mister_bin', '~> 0.7'
-  s.add_runtime_dependency 'mustermann', '>= 1.1', '< 4'
-  s.add_runtime_dependency 'puma', '>= 5.3', '< 7'
-  s.add_runtime_dependency 'rack', '~> 3.0'
-  s.add_runtime_dependency 'rackup', '~> 2.1'
+  s.add_dependency 'mister_bin', '~> 0.7'
+  s.add_dependency 'mustermann', '>= 1.1', '< 4'
+  s.add_dependency 'puma', '>= 5.3', '< 7'
+  s.add_dependency 'rack', '~> 3.0'
+  s.add_dependency 'rackup', '~> 2.1'
 
   s.metadata = {
     'bug_tracker_uri'       => 'https://github.com/DannyBen/redirectly/issues',

--- a/spec/approvals/cli/init-template
+++ b/spec/approvals/cli/init-template
@@ -3,4 +3,5 @@ example.com = https://other-site.com/
 example.org/* = https://other-site.com/
 *.old-site.com = !https://permanent.redirect.com
 :sub.app.localhost/* = http://it-works.com/%{sub}
+proxy.localhost/*rest = @https://proxy.target.com/base/*rest
 (*)old-domain.com/*rest = http://new-domain.com/%{rest}

--- a/spec/fixtures/redirects.ini
+++ b/spec/fixtures/redirects.ini
@@ -4,5 +4,7 @@ test.localhost/* = https://test.com/
 perm.localhost = !https://permanent.com
 :sub.domain.com = https://new-site.com/%{sub}
 query.com = https://redir.com?already=have&query=string
+proxy.localhost/*rest = @https://echo.free.beeceptor.com/basepath/%{rest}
+invalid-proxy.localhost = @https://no.such.domain.com
 *.localhost = https://anything-else.com
 (*)splat.localhost/*rest = https://example.com/%{rest}

--- a/spec/redirectly/app_spec.rb
+++ b/spec/redirectly/app_spec.rb
@@ -86,6 +86,29 @@ describe App do
     end
   end
 
+  context 'with a target that wants a proxy' do
+    subject { host_get url }
+
+    let(:url) { 'proxy.localhost/path?query=string' }
+    let(:parsed_response) { JSON.parse last_response.body }
+
+    it 'reads and serves the content from the target' do
+      expect(subject).to be_successful
+      expect(last_response.content_type).to eq 'application/json'
+      expect(parsed_response['path']).to eq '/basepath/path?query=string'
+    end
+
+    context 'when the target raises an error' do
+      let(:url) { 'invalid-proxy.localhost' }
+
+      it 'returns 502 Bad Gateway' do
+        expect(subject).to_not be_successful
+        expect(last_response.status).to eq 502
+        expect(last_response.body).to include 'Bad Gateway'
+      end
+    end
+  end
+
   context 'with an unknown request' do
     subject { host_get 'no.such.pattern/here' }
 

--- a/spec/redirectly/command_spec.rb
+++ b/spec/redirectly/command_spec.rb
@@ -9,7 +9,7 @@ describe Command do
   context 'without arguments' do
     it 'starts the server with redirects.yml' do
       Dir.chdir 'spec/fixtures' do
-        expect(Rack::Server).to receive(:start).with(default_args)
+        expect(Rackup::Server).to receive(:start).with(default_args)
         subject.run
       end
     end
@@ -51,7 +51,7 @@ describe Command do
 
   context 'with a CONFIG argument' do
     it 'starts the server with the specified path' do
-      expect(Rack::Server).to receive(:start).with(default_args)
+      expect(Rackup::Server).to receive(:start).with(default_args)
       subject.run %w[spec/fixtures/redirects.ini]
     end
   end
@@ -60,7 +60,7 @@ describe Command do
     let(:args) { { app: Redirectly::App, Port: 1234, environment: 'production' } }
 
     it 'starts the server and listens on the requested port' do
-      expect(Rack::Server).to receive(:start).with(args)
+      expect(Rackup::Server).to receive(:start).with(args)
       subject.run %w[spec/fixtures/redirects.ini --port 1234]
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 require 'simplecov'
-SimpleCov.start { enable_coverage :branch }
+
+unless ENV['NOCOV']
+  SimpleCov.start do
+    enable_coverage :branch if ENV['BRANCH_COV']
+    coverage_dir 'spec/coverage'
+  end
+end
 
 require 'bundler'
 Bundler.require :default, :development


### PR DESCRIPTION
cc #13

This PR adds support for proxying content instead of redirecting to it, by prefixing the target URL in the configuraiton file with `@`:

```ini
proxy.localhost/:anything = @https://github.com/DannyBen/%{anything}
```

