### PR TITLE
Allow reloading the INI file using `REDIRECTLY_RELOAD` or `--reload`

### DIFF
--- a/lib/redirectly/app.rb
+++ b/lib/redirectly/app.rb
@@ -63,7 +63,11 @@ module Redirectly
     end
 
     def redirects
-      @redirects ||= ini_read(config_path)
+      if ENV['REDIRECTLY_RELOAD']
+        ini_read config_path
+      else
+        @redirects ||= ini_read(config_path)
+      end
     end
 
     def ini_read(path)

--- a/lib/redirectly/command.rb
+++ b/lib/redirectly/command.rb
@@ -8,12 +8,13 @@ module Redirectly
     help 'Start the redirect server'
     version Redirectly::VERSION
 
-    usage 'redirectly [CONFIG --port PORT]'
+    usage 'redirectly [CONFIG --port PORT --reload]'
     usage 'redirectly --init'
     usage 'redirectly -h | --help | --version'
 
     option '-p --port PORT', 'Listening port [default: 3000]'
     option '-i --init', 'Create a sample config file and exit'
+    option '-r --reload', 'Read the INI file with every request'
 
     param 'CONFIG', 'Path to config file [default: redirects.ini]'
 
@@ -52,6 +53,7 @@ module Redirectly
     def start_server
       raise ArgumentError, "Cannot find config file #{config_path}" unless File.exist? config_path
 
+      ENV['REDIRECTLY_RELOAD'] = '1' if args['--reload']
       Rackup::Server.start(app: app, Port: port, environment: 'production')
     end
 

--- a/spec/approvals/cli/help
+++ b/spec/approvals/cli/help
@@ -1,7 +1,7 @@
 Start the redirect server
 
 Usage:
-  redirectly [CONFIG --port PORT]
+  redirectly [CONFIG --port PORT --reload]
   redirectly --init
   redirectly -h | --help | --version
 
@@ -11,6 +11,9 @@ Options:
 
   -i --init
     Create a sample config file and exit
+
+  -r --reload
+    Read the INI file with every request
 
   -h --help
     Show this help

--- a/spec/redirectly/app_spec.rb
+++ b/spec/redirectly/app_spec.rb
@@ -102,7 +102,7 @@ describe App do
       let(:url) { 'invalid-proxy.localhost' }
 
       it 'returns 502 Bad Gateway' do
-        expect(subject).to_not be_successful
+        expect(subject).not_to be_successful
         expect(last_response.status).to eq 502
         expect(last_response.body).to include 'Bad Gateway'
       end
@@ -114,6 +114,18 @@ describe App do
 
     it 'responds with a 404' do
       expect(subject).to be_not_found
+    end
+  end
+
+  context 'when env var REDIRECTLY_RELOAD is set' do
+    let(:app) { Redirectly::App.new config_path }
+
+    before { ENV['REDIRECTLY_RELOAD'] = '1' }
+    after { ENV['REDIRECTLY_RELOAD'] = nil }
+
+    it 'reloads the INI file with each request' do
+      expect(app).to receive(:ini_read).twice.and_call_original
+      2.times { app.call(Rack::MockRequest.env_for('http://test.localhost/')) }
     end
   end
 end

--- a/spec/redirectly/command_spec.rb
+++ b/spec/redirectly/command_spec.rb
@@ -64,4 +64,14 @@ describe Command do
       subject.run %w[spec/fixtures/redirects.ini --port 1234]
     end
   end
+
+  context 'with --reload' do
+    before { ENV['REDIRECTLY_RELOAD'] = nil }
+
+    it 'starts the server and listens on the requested port' do
+      expect(Rackup::Server).to receive(:start).with(default_args)
+      subject.run %w[spec/fixtures/redirects.ini --reload]
+      expect(ENV['REDIRECTLY_RELOAD']).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
cc #15 

This PR allows running the server in a "reload" mode - where the INI file will be read with every request, instead of being read once only on the first request.

To enable this method, either set the `REDIRECTLY_RELOAD` environment variable to a non empty value, or run `redirectly --reload`.
