### PR TITLE
Add support for defining a URL that reloads the INI file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
+--require spec_helper
 --color
 --format documentation
 --fail-fast

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ example.org/* = https://other-site.com/
 *.old-site.com = !https://permanent.redirect.com
 :sub.app.localhost/* = http://it-works.com/%{sub}
 proxy.localhost/*rest = @https://proxy.target.com/base/*rest
+internal.localhost/reload = :reload
 (*)old-domain.com/*rest = http://new-domain.com/%{rest}
 ```
 
@@ -110,24 +111,44 @@ The configuration file is built of `pattern = target` pairs, where:
 - `pattern` - is any URL pattern that is supported by [Mustermann][mustermann].
 - `target` - is the target URL to redirect to.
 
-### Notes
+### Special INI Notation
 
-#### Redirects
+#### Redirect type
 
-If the target starts with `!`, it will perform a permanent redirect (301).
-Otherwise, it will perform a temporary redirect (302) by default.
+If the target starts with `!`, a permanent redirect (301) will be performed.  
+If it does not, a temporary redirect (302) will be performed by default:
+
+```ini
+test.localhost/temporary = http://example.com
+test.localhost/permanent = !http://example.com
+```
 
 #### Proxying
 
 If the target starts with `@`, the content will be proxied instead of being
-redirected.
+redirected:
 
-#### Named Arguments in Patterns
+```ini
+test.localhost = @http://example.com
+```
 
-If the pattern includes named arguments (e.g., example.com/**:something**),
-those arguments will be available as Ruby string substitution variables in the
-target (e.g., **%{something}**).
+#### Named arguments
 
+Patterns that include strings starting with a colon `:` will expose those
+strings as Ruby substitution variables in the target:
+
+```ini
+test.localhost/:anything = http://example.com/path/%{anything}
+```
+
+#### Splats
+
+You can use a splat `*` or a named splat `*name` in the pattern.  
+Named splats will also be exposed as Ruby substitution variables in the target:
+
+```ini
+(*)test.localhost/*rest = http://example.com/%{rest}
+```
 
 ## Contributing / Support
 

--- a/lib/redirectly/app.rb
+++ b/lib/redirectly/app.rb
@@ -16,7 +16,7 @@ module Redirectly
 
     def call(env)
       @req = Rack::Request.new env
-      found = match
+      found = find_match
 
       if found
         handle_target found
@@ -75,7 +75,7 @@ module Redirectly
       content.to_h { |line| line.split(/\s*=\s*/, 2) }
     end
 
-    def match
+    def find_match
       redirects.each do |pattern, target|
         found = find_target pattern, target
         return found if found

--- a/lib/redirectly/app.rb
+++ b/lib/redirectly/app.rb
@@ -28,7 +28,9 @@ module Redirectly
   private
 
     def handle_target(target)
-      if target.start_with? '@'
+      if target.start_with? ':'
+        run_internal_command target[1..]
+      elsif target.start_with? '@'
         proxy_to target[1..]
       else
         redirect_to target
@@ -58,6 +60,13 @@ module Redirectly
       [502, { 'Content-Type' => 'text/plain' }, ["Bad Gateway: #{e.message}"]]
     end
 
+    def run_internal_command(target)
+      case target.to_sym
+      when :reload then reload_ini
+      else not_found
+      end
+    end
+
     def not_found
       [404, { 'content-type' => 'text/plain' }, ['Not Found']]
     end
@@ -68,6 +77,11 @@ module Redirectly
       else
         @redirects ||= ini_read(config_path)
       end
+    end
+
+    def reload_ini
+      @redirects = nil
+      [200, { 'content-type' => 'text/plain' }, ['OK (:reload)']]
     end
 
     def ini_read(path)

--- a/lib/redirectly/command.rb
+++ b/lib/redirectly/command.rb
@@ -18,7 +18,8 @@ module Redirectly
 
     param 'CONFIG', 'Path to config file [default: redirects.ini]'
 
-    environment 'REDIRECTLY_RELOAD', 'Set to a non empty value in order to read the INI file with every request (same as --reload)'
+    environment 'REDIRECTLY_RELOAD',
+      'Set to a non empty value in order to read the INI file with every request (same as --reload)'
 
     example 'redirectly --init'
     example 'redirectly config.ini --port 4000 --reload'

--- a/lib/redirectly/command.rb
+++ b/lib/redirectly/command.rb
@@ -48,6 +48,7 @@ module Redirectly
         *.old-site.com = !https://permanent.redirect.com
         :sub.app.localhost/* = http://it-works.com/%{sub}
         proxy.localhost/*rest = @https://proxy.target.com/base/*rest
+        internal.localhost/reload = :reload
         (*)old-domain.com/*rest = http://new-domain.com/%{rest}
       TEMPLATE
     end

--- a/spec/approvals/cli/init-template
+++ b/spec/approvals/cli/init-template
@@ -4,4 +4,5 @@ example.org/* = https://other-site.com/
 *.old-site.com = !https://permanent.redirect.com
 :sub.app.localhost/* = http://it-works.com/%{sub}
 proxy.localhost/*rest = @https://proxy.target.com/base/*rest
+internal.localhost/reload = :reload
 (*)old-domain.com/*rest = http://new-domain.com/%{rest}

--- a/spec/fixtures/redirects.ini
+++ b/spec/fixtures/redirects.ini
@@ -6,5 +6,7 @@ perm.localhost = !https://permanent.com
 query.com = https://redir.com?already=have&query=string
 proxy.localhost/*rest = @https://echo.free.beeceptor.com/basepath/%{rest}
 invalid-proxy.localhost = @https://no.such.domain.com
+reload.localhost = :reload
+invalid-command.localhost = :reboot
 *.localhost = https://anything-else.com
 (*)splat.localhost/*rest = https://example.com/%{rest}

--- a/spec/redirectly/app_spec.rb
+++ b/spec/redirectly/app_spec.rb
@@ -107,6 +107,23 @@ describe App do
     end
   end
 
+  context 'with an internal :reload target' do
+    subject { host_get 'reload.localhost' }
+
+    it 'reloads the INI file' do
+      expect(subject).to be_successful
+      expect(last_response.body).to eq 'OK (:reload)'
+    end
+  end
+
+  context 'with an unknown internal command target' do
+    subject { host_get 'invalid-command.localhost' }
+
+    it 'responds with a 404' do
+      expect(subject).to be_not_found
+    end
+  end
+
   context 'with an unknown request' do
     subject { host_get 'no.such.pattern/here' }
 

--- a/spec/redirectly/app_spec.rb
+++ b/spec/redirectly/app_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe App do
   let(:config_path) { 'spec/fixtures/redirects.ini' }
 

--- a/spec/redirectly/bin_errors_spec.rb
+++ b/spec/redirectly/bin_errors_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'bin/redirectly error handling' do
   it 'errors gracefully' do
     expect(`bin/redirectly no-such-file.ini`).to match_approval('bin/error')

--- a/spec/redirectly/command_spec.rb
+++ b/spec/redirectly/command_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Command do
   subject { CLI.router }
 

--- a/spec/redirectly/refinements_spec.rb
+++ b/spec/redirectly/refinements_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Refinements do
   using described_class
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ require 'redirectly/cli'
 
 include Redirectly
 
+ENV['REDIRECTLY_RELOAD'] = nil
+
 RSpec.configure do |config|
   config.include Rack::Test::Methods
 


### PR DESCRIPTION
cc #15

Using the keyword `:reload` as a target in the INI file, will create a URL that can be called to reload the INI file.

```ini
test.localhost/reset = :reload
```
