### PR TITLE
Update INI reader to ignore sections

### DIFF
--- a/lib/redirectly/app.rb
+++ b/lib/redirectly/app.rb
@@ -85,7 +85,7 @@ module Redirectly
     end
 
     def ini_read(path)
-      content = File.readlines(path, chomp: true).reject(&:comment?).reject(&:empty?)
+      content = File.readlines(path, chomp: true).reject(&:ignored?)
       content.to_h { |line| line.split(/\s*=\s*/, 2) }
     end
 

--- a/lib/redirectly/refinements.rb
+++ b/lib/redirectly/refinements.rb
@@ -1,8 +1,16 @@
 module Redirectly
   module Refinements
     refine String do
+      def ignored?
+        empty? || comment? || section?
+      end
+
       def comment?
-        start_with? ';' or start_with? '#'
+        start_with?(';') || start_with?('#')
+      end
+
+      def section?
+        match?(/^\[.+\]$/)
       end
     end
   end

--- a/spec/fixtures/redirects.ini
+++ b/spec/fixtures/redirects.ini
@@ -1,12 +1,18 @@
+; Comments are ignored
+# Comments are also ignored
+[Sections are ignored]
 search.localhost = https://search.com
 find.localhost/:anything = https://search.com/?q=%{anything}
 test.localhost/* = https://test.com/
 perm.localhost = !https://permanent.com
+
 :sub.domain.com = https://new-site.com/%{sub}
 query.com = https://redir.com?already=have&query=string
 proxy.localhost/*rest = @https://echo.free.beeceptor.com/basepath/%{rest}
 invalid-proxy.localhost = @https://no.such.domain.com
+
 reload.localhost = :reload
 invalid-command.localhost = :reboot
+
 *.localhost = https://anything-else.com
 (*)splat.localhost/*rest = https://example.com/%{rest}

--- a/spec/redirectly/refinements_spec.rb
+++ b/spec/redirectly/refinements_spec.rb
@@ -15,5 +15,34 @@ describe Refinements do
         expect('not a nice comment'.comment?).to be false
       end
     end
+
+    describe '#section?' do
+      it 'returns true for a line that looks like an INI section' do
+        expect('[INI section]'.section?).to be true
+      end
+
+      it 'returns false for other lines' do
+        expect('[Not a section'.section?).to be false
+        expect('; [Not a section]'.section?).to be false
+      end
+    end
+
+    describe '#ignored?' do
+      it 'returns true for comments' do
+        expect('; ignored'.ignored?).to be true
+      end
+
+      it 'returns true for empty lines' do
+        expect(''.ignored?).to be true
+      end
+
+      it 'returns true for sections lines' do
+        expect('[section]'.ignored?).to be true
+      end
+
+      it 'returns false for other lines' do
+        expect('line'.ignored?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR changes the INI reader to ignore `[sections]`.
The rationale is to allow the INI file to include sections, in case it is created / updated by other means as presented in #18.
